### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 # Based on https://github.com/snok/install-poetry
 name: CI
 
+permissions:
+  contents: read
+
 on: push
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/jfroy/aiobafi6/security/code-scanning/1](https://github.com/jfroy/aiobafi6/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow primarily interacts with repository contents (e.g., checking out code and caching dependencies), the `contents: read` permission is sufficient. This limits the `GITHUB_TOKEN` to read-only access to the repository contents, adhering to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file, ensuring it applies to all jobs in the workflow. No additional imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
